### PR TITLE
Fire ASN event on every request to eBay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,94 @@ And then execute:
 
     $ bundle
 
+## Request events
+
+The gem fires ASN event on every request to eBay API.
+
+Default event name is `ebay_trading_api.request.details`.
+
+Event payload is a Hash which contains the following data:
+- `:api_endpoint` -- call name, i.e. 'GeteBayOfficialTime'
+- `:api_version` -- API schema version, i.e. '1211'
+- `:method` -- request method, always 'post' as no other is used
+- `:request_context` -- a Hash with additional request context, by default contains `site_id`,
+- `:response` _(optional)_ -- contains a response object type of `Ebay::Response`; exists only when the request reached eBay API.
+- `:exception` _(optional)_ -- contains exception data when the exception raised on reaching eBay API, i.e. request timeout; format is `[exception_class_name, exception_message]` (see `ActiveSupport` documentation on this),
+- `:exception_object` _(optional)_ -- contains original exception object in case of exception (see `ActiveSupport` documentation on this).
+
+Example successful payload:
+
+```ruby
+{
+  api_endpoint: 'GeteBayOfficialTime',
+  api_version: '1211',
+  method: 'post',
+  request_context: { site_id: 3 },
+  response: #<Ebay::Response:0x0000557285b0f9d0
+    @body=
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<GeteBayOfficialTimeResponse xmlns=\"urn:ebay:apis:eBLBaseComponents\"><Timestamp>2006-07-05T14:23:03.399Z</Timestamp><Ack>Success</Ack><Version>467</Version><Build>e467_core_Bundled_3145691_R1</Build></GeteBayOfficialTimeResponse>\n",
+    @code=200,
+    @headers={}>
+}
+```
+
+Example payload with exception:
+```ruby
+{
+  api_endpoint: 'GeteBayOfficialTime',
+  api_version: '1211',
+  method: 'post',
+  request_context: { site_id: 3 },
+  exception: ['Errno::ECONNRESET', 'Connection reset by peer - SSL_connect'],
+  exception_object: #<Errno::ECONNRESET: Connection reset by peer - SSL_connect>
+}
+```
+
+### Events configuration
+
+#### Event name
+
+Event name can be configured:
+
+```ruby
+Ebay::Api.configure do |config|
+  config.request_event_name = 'custom_event_name'
+end
+```
+
+#### Request context
+
+`request_context` can be extended via the API client initializer:
+
+```ruby
+ebay_api = Ebay::Api.new ebay_auth_token: auth_token, site_id: 3, request_context: { foo: :bar }
+```
+
+or set for the existing client object:
+
+```ruby
+ebay_api = Ebay::Api.new ebay_auth_token: auth_token, site_id: 3
+ebay_api.request_context = { foo: :bar }
+```
+
+so the `request_context` in the `payload` will contain passed data:
+
+```ruby
+{
+  # ...
+  request_context: { site_id: 3, foo: :bar }
+}
+```
+
+### Subscription
+
+As long as the event as default ASN events, subscription logic is the same as for any other ASN event.
+
+```ruby
+ActiveSupport::Notifications.subscribe(Ebay::Api.request_event_name) do |name, start_time, end_time, _, payload|
+  puts payload
+end
+```
 
 ## Testing
 

--- a/test/http_mock.rb
+++ b/test/http_mock.rb
@@ -1,5 +1,11 @@
 module Ebay
   class HttpMock
+    class NoResponseRecorded < StandardError
+      def message
+        @message || 'No more responses have been recorded'
+      end
+    end
+
     class << self
       def responses
         @@responses ||= []
@@ -16,7 +22,7 @@ module Ebay
     end
 
     def post(*args)
-      self.class.responses.shift || raise("No more responses have been recorded")
+      self.class.responses.shift || raise(NoResponseRecorded)
     end
 
     def initialize(site)

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -43,4 +43,22 @@ class ConfigTest < Test::Unit::TestCase
     end
     assert_equal OpenSSL::SSL::VERIFY_NONE, Api.ssl_verify_mode
   end
+
+  def test_default_request_event_name
+    assert_equal 'ebay_trading_api.request.details', Api.request_event_name
+  end
+
+  def test_override_request_event_name
+    default_request_event_name = Api.request_event_name
+
+    Api.configure do |config|
+      config.request_event_name = 'ebay.request'
+    end
+
+    assert_equal 'ebay.request', Api.request_event_name
+
+    Api.configure do |config|
+      config.request_event_name = default_request_event_name
+    end
+  end
 end

--- a/test/unit/ebay_test.rb
+++ b/test/unit/ebay_test.rb
@@ -162,4 +162,18 @@ class EbayTest < Test::Unit::TestCase
       @ebay.get_sushi
     end
   end
+
+  def test_default_request_context
+    ebay_api = Api.new(site_id: 2)
+    default_request_context = {}
+
+    assert_equal default_request_context, ebay_api.request_context
+  end
+
+  def test_override_request_context
+    expected_request_context = { foo: :bar }
+    ebay_api = Api.new(site_id: 2, request_context: expected_request_context)
+
+    assert_equal expected_request_context, ebay_api.request_context
+  end
 end

--- a/test/unit/http_mock_test.rb
+++ b/test/unit/http_mock_test.rb
@@ -1,0 +1,25 @@
+require File.dirname(__FILE__) + '/../test_helper'
+
+class HttpMockTest < Test::Unit::TestCase
+  include Ebay
+  include Ebay::Types
+
+  def setup
+    @ebay_api = Api.new
+  end
+
+  def test_exception_on_no_response_recorded
+    assert_raise(Ebay::HttpMock::NoResponseRecorded) { @ebay_api.get_ebay_official_time }
+  end
+
+  def test_response_when_recorded
+    recorded_response = responses(:official_time_success)
+    Ebay::HttpMock.respond_with(recorded_response)
+
+    response = @ebay_api.get_ebay_official_time
+
+    expected_timestamp = recorded_response.body.match("<Timestamp>?(.*)</Timestamp>")[1].to_time.utc.iso8601
+
+    assert_equal expected_timestamp, response.timestamp.iso8601
+  end
+end

--- a/test/unit/request_notifications_test.rb
+++ b/test/unit/request_notifications_test.rb
@@ -1,0 +1,232 @@
+require File.dirname(__FILE__) + '/../test_helper'
+
+class RequestNotificationsTest < Test::Unit::TestCase
+  include Ebay
+  include Ebay::Types
+
+  def setup
+    @ebay_api = Api.new site_id: 3
+    @success = responses(:official_time_success)
+    @failure = responses(:official_time_failure, code: 400)
+  end
+
+  def test_default_event_name
+    Ebay::HttpMock.respond_with(@success)
+
+    with_subscription_to_events do |events|
+      @ebay_api.get_ebay_official_time
+
+      assert_equal 1, events.size
+
+      assert_equal Ebay::Api::DEFAULT_REQUEST_EVENT_NAME, events.last[0]
+    end
+  end
+
+  # Shows that configured event name
+  # via 'request_event_name' is applied
+  # to fired events. Example config:
+  #
+  # Ebay::Api.configure do |api|
+  #   api.request_event_name = 'custom_event_name'
+  # end
+  #
+  # So events with customized name will be fired.
+  def test_custom_event_name
+    custom_event_name = 'ebay.request'
+
+    default_event_name = Api.request_event_name
+    Api.request_event_name = custom_event_name
+
+    Ebay::HttpMock.respond_with(@success)
+
+    with_subscription_to_events do |events|
+      @ebay_api.get_ebay_official_time
+
+      assert_equal 1, events.size
+
+      assert_equal custom_event_name, events.last[0]
+    end
+
+    Api.request_event_name = default_event_name
+  end
+
+  def test_notification_fired_on_successful_request
+    Ebay::HttpMock.respond_with(@success)
+
+    with_subscription_to_events do |events|
+      @ebay_api.get_ebay_official_time
+
+      assert_equal 1, events.size
+
+      assert_common_event_data(
+        events.last,
+        expected_api_endpoint: 'GeteBayOfficialTime'
+      )
+      assert_response_in(events.last, expected_status: 200)
+    end
+  end
+
+  def test_notification_fired_on_failed_request
+    Ebay::HttpMock.respond_with(@failure)
+
+    with_subscription_to_events do |events|
+      # Ebay::ClientError is raised because of response status 400
+      assert_raise(Ebay::ClientError) { @ebay_api.get_ebay_official_time }
+
+      assert_equal 1, events.size
+
+      assert_common_event_data(
+        events.last,
+        expected_api_endpoint: 'GeteBayOfficialTime'
+      )
+      assert_response_in(events.last, expected_status: 400)
+    end
+  end
+
+  # Shows that request context can be defined
+  # for entire client context like:
+  #
+  # Ebay::Api.new(
+  #   auth_token: ebay_auth_token,
+  #   site_id: site_id,
+  #   request_context: { foo: :bar }
+  # )
+  #
+  # So this context will be propagated to the ASN event
+  def test_notification_with_predefined_request_context
+    custom_request_context = { foo: :bar, baz: :qux }
+    @ebay_api = Api.new site_id: 3, request_context: custom_request_context
+
+    expected_request_context = { site_id: 3 }.merge(custom_request_context)
+
+    Ebay::HttpMock.respond_with(@success)
+
+    with_subscription_to_events do |events|
+      @ebay_api.get_ebay_official_time
+
+      assert_equal 1, events.size
+      event_payload = events.last.last
+
+      assert_equal expected_request_context, event_payload[:request_context]
+    end
+  end
+
+  # Shows that request context can be changed
+  # any time for entire client context like:
+  #
+  # ebay_api = Ebay::Api.new(
+  #   auth_token: ebay_auth_token,
+  #   site_id: site_id
+  # )
+  # ebay_api.request_context = { foo: :bar }
+  #
+  # So this context will be set for the client
+  # and will propagated to the ASN event.
+  def test_notification_with_changed_request_context
+    custom_request_context = { foo: :bar, baz: :qux }
+    @ebay_api.request_context = custom_request_context
+
+    expected_request_context = { site_id: 3 }.merge(custom_request_context)
+
+    Ebay::HttpMock.respond_with(@success)
+
+    with_subscription_to_events do |events|
+      @ebay_api.get_ebay_official_time
+
+      assert_equal 1, events.size
+      event_payload = events.last.last
+
+      assert_equal expected_request_context, event_payload[:request_context]
+    end
+  end
+
+  def test_notification_with_exception
+    expected_exception_class = Ebay::HttpMock::NoResponseRecorded
+    expected_exception_data = [expected_exception_class.to_s, 'No more responses have been recorded']
+
+    with_subscription_to_events do |events|
+      # emulate attempting to reach external API
+      # which fails because of missing request mock
+      # and external requests are not allowed
+      assert_raise(expected_exception_class) { @ebay_api.get_ebay_official_time }
+
+      assert_equal 1, events.size
+
+      event_payload = events.last.last
+
+      # response is blank as the request didn't reach eBay
+      assert_equal true, event_payload[:response].blank?
+
+      # event contains exception data
+      assert_equal expected_exception_data, event_payload[:exception]
+      assert_equal expected_exception_class, event_payload[:exception_object].class
+      assert_equal 'No more responses have been recorded', event_payload[:exception_object].message
+    end
+  end
+
+  def test_notification_api_version
+    Ebay::HttpMock.respond_with(@success)
+    requested_api_version = '1234'
+
+    with_subscription_to_events do |events|
+      @ebay_api.get_ebay_official_time(requested_api_version: requested_api_version)
+
+      assert_equal 1, events.size
+
+      assert_common_event_data(
+        events.last,
+        expected_api_endpoint: 'GeteBayOfficialTime',
+        expected_api_version: requested_api_version
+      )
+    end
+  end
+
+  def test_notification_api_method
+    Ebay::HttpMock.respond_with(responses(:verify_add_item))
+
+    with_subscription_to_events do |events|
+      @ebay_api.verify_add_item
+
+      assert_equal 1, events.size
+
+      assert_common_event_data(events.last, expected_api_endpoint: 'VerifyAddItem')
+    end
+  end
+
+  private
+
+  def with_subscription_to_events
+    events = []
+    subscriber = ActiveSupport::Notifications.subscribe(Api.request_event_name) do |*args|
+      events << args
+    end
+
+    yield(events)
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  def assert_common_event_data(event,
+    expected_api_endpoint:,
+    expected_api_version: Ebay::Schema::VERSION.to_s,
+    expected_request_context: { site_id: 3 })
+
+    _name, event_start_time, event_end_time, _id, event_payload = event
+
+    # assert request details
+    assert_equal expected_api_endpoint, event_payload[:api_endpoint]
+    assert_equal expected_api_version, event_payload[:api_version]
+    assert_equal :post, event_payload[:method]
+    assert_equal expected_request_context, event_payload[:request_context]
+
+    # assert event details
+    assert_not_equal 0, event_end_time - event_start_time
+  end
+
+  def assert_response_in(event, expected_status: 200)
+    event_payload = event.last
+
+    assert_equal Ebay::Response, event_payload[:response].class
+    assert_equal expected_status, event_payload[:response].code
+  end
+end


### PR DESCRIPTION
* Fire ASN event on every request to eBay API with the following payload:
  * `:api_endpoint` -- call name, i.e. 'GeteBayOfficialTime'
  * `:api_version` -- API schema version, i.e. '1211'
  * `:method` -- request method, always 'post' as no other is used
  * `:request_context` -- a Hash with additional request context, by default contains `site_id`,
  * `:response` _(optional)_ -- contains a response object type of `Ebay::Response`; exists only when the request reached eBay API.
  * `:exception` _(optional)_ -- contains exception data when the exception raised on reaching eBay API, i.e. request timeout; format is `[exception_class_name, exception_message]` (see `ActiveSupport` documentation on this),
  * `:exception_object` _(optional)_ -- contains original exception object in case of exception (see `ActiveSupport` documentation on this).
* Allow providing metadata (request context) for the event; `site_id` is passed by default;
* Default ASN event name `ebay_trading_api.request.details`; allow configuring it.

See README.md for more details.