### PR TITLE
Recognize an error when an item can't be accessed

### DIFF
--- a/lib/ebay/api.rb
+++ b/lib/ebay/api.rb
@@ -24,6 +24,7 @@ module Ebay #:nodoc:
   end
 
   class RequestLimitExceeded < RequestError; end
+  class ItemNotAccessible < RequestError; end
 
   # == Overview
   # Api is the main proxy class responsible for instantiating and invoking

--- a/test/fixtures/responses/get_item_with_item_not_accessible.xml
+++ b/test/fixtures/responses/get_item_with_item_not_accessible.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<GetItemResponse xmlns='urn:ebay:apis:eBLBaseComponents'>
+  <Timestamp>2023-10-16T14:57:46.740Z</Timestamp>
+  <Ack>Failure</Ack>
+  <Errors>
+    <ShortMessage>Item can&apos;t be accessed.</ShortMessage>
+    <LongMessage>This item cannot be accessed because the listing has been deleted or you are not the seller.</LongMessage>
+    <ErrorCode>17</ErrorCode>
+    <SeverityCode>Error</SeverityCode>
+    <ErrorParameters ParamID='0'>
+      <Value>123456789</Value>
+    </ErrorParameters>
+    <ErrorClassification>RequestError</ErrorClassification>
+  </Errors>
+  <Version>1193</Version>
+  <Build>E1193_CORE_API_19146280_R1</Build>
+  <Item/>
+</GetItemResponse>

--- a/test/fixtures/responses/get_item_with_multiple_failures.xml
+++ b/test/fixtures/responses/get_item_with_multiple_failures.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<GetItemResponse xmlns='urn:ebay:apis:eBLBaseComponents'>
+  <Timestamp>2023-10-16T14:57:46.740Z</Timestamp>
+  <Ack>Failure</Ack>
+  <Errors>
+    <ShortMessage>Item can&apos;t be accessed.</ShortMessage>
+    <LongMessage>This item cannot be accessed because the listing has been deleted or you are not the seller.</LongMessage>
+    <ErrorCode>17</ErrorCode>
+    <SeverityCode>Error</SeverityCode>
+    <ErrorParameters ParamID='0'>
+      <Value>123456789</Value>
+    </ErrorParameters>
+    <ErrorClassification>RequestError</ErrorClassification>
+  </Errors>
+  <Errors>
+    <ShortMessage>Your application has exceeded usage limit on this call.</ShortMessage>
+    <LongMessage>Your application has exceeded usage limit on this call, please make call to Developer Analytics API to check your call usage.</LongMessage>
+    <ErrorCode>518</ErrorCode>
+    <SeverityCode>Error</SeverityCode>
+    <ErrorParameters ParamID='0'>
+      <Value>123456789</Value>
+    </ErrorParameters>
+    <ErrorClassification>RequestError</ErrorClassification>
+  </Errors>
+  <Version>1193</Version>
+  <Build>E1193_CORE_API_19146280_R1</Build>
+  <Item/>
+</GetItemResponse>


### PR DESCRIPTION
Raise `ItemNotAccessible` exception instead of general `RequestError` on receiving an error with a code of `17` according to https://developer.ebay.com/devzone/xml/docs/Reference/eBay/Errors/ErrorMessages.html#ErrorsByNumber