### PR TITLE
Add support for authorization with OAuth2 token

### DIFF
--- a/examples/config.template.rb
+++ b/examples/config.template.rb
@@ -1,10 +1,14 @@
 # Copy this file and paste it into a new file called config.rb
 # Then, replace the values where appropriate below and save.
 Ebay::Api.configure do |ebay|
+  # Traditional Auth'n'Auth credentials
   ebay.auth_token = 'YOUR AUTH TOKEN HERE'
   ebay.dev_id = 'YOUR DEVELOPER ID HERE'
   ebay.app_id = 'YOUR APPLICATION ID HERE'
   ebay.cert = 'YOUR CERTIFICATE HERE'
+
+  # OAuth2 token (alternative to Auth'n'Auth)
+  # ebay.rest_api_oauth_token = 'YOUR OAUTH2 TOKEN HERE'
 
   # The default environment is the production environment
   # Override by setting use_sandbox to true

--- a/examples/get_orders_oauth.rb
+++ b/examples/get_orders_oauth.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/ruby
+$:.unshift File.dirname(__FILE__)
+$:.unshift File.join(File.dirname(__FILE__),'..', 'lib')
+
+require 'ebay'
+
+# Configure eBay API with OAuth2 token
+Ebay::Api.configure do |ebay|
+  ebay.rest_api_oauth_token = 'YOUR_OAUTH2_TOKEN_HERE'
+  ebay.use_sandbox = true  # Set to false for production
+end
+
+# Create API instance
+ebay = Ebay::Api.new
+
+begin
+  # Get orders using OAuth2 authentication
+  response = ebay.get_orders(
+    create_time_from: Time.parse('2025-11-12T21:59:59.005Z'),
+    create_time_to: Time.parse('2025-12-28T21:59:59.005Z'),
+    order_role: 'Seller',
+    order_status: 'Completed',
+    pagination: Ebay::Types::Pagination.new(entries_per_page: 2)
+  )
+
+  puts "Successfully retrieved orders using OAuth2!"
+  puts "Total orders: #{response.pagination_result.total_number_of_entries}"
+  puts "Orders returned: #{response.returned_order_count_actual}"
+
+  if response.orders && response.orders.any?
+    response.order_array.each_with_index do |order, index|
+      puts "Order #{index + 1}: #{order.order_id}"
+    end
+  else
+    puts "No orders found in the specified date range"
+  end
+
+rescue Ebay::RequestError => e
+  puts "eBay API Error:"
+  e.errors.each do |error|
+    puts "  #{error.short_message}: #{error.long_message}"
+  end
+rescue => e
+  puts "Error: #{e.message}"
+end

--- a/lib/ebay/api.rb
+++ b/lib/ebay/api.rb
@@ -176,6 +176,8 @@ module Ebay #:nodoc:
         params[:username] = username
         params[:password] = password
         params[:auth_token] = auth_token
+        # Pass OAuth2 token to request object
+        params[:rest_api_oauth_token] = @rest_api_oauth_token if @rest_api_oauth_token
       end
 
       request = request_class.new(params)

--- a/lib/ebay/requests/abstract.rb
+++ b/lib/ebay/requests/abstract.rb
@@ -44,7 +44,12 @@ module Ebay # :nodoc:
         @detail_levels = Array(value)
       end
       
+      attr_accessor :rest_api_oauth_token
+      
       def requester_credentials
+        # Skip RequesterCredentials when using OAuth2
+        return nil if respond_to?(:rest_api_oauth_token) && rest_api_oauth_token
+      
         if auth_token || username || password
           XMLRequesterCredentials.new(:ebay_auth_token => auth_token, :username => username, :password => password)
         end

--- a/lib/ebay/schema/mapper/templates/abstract_request.erb
+++ b/lib/ebay/schema/mapper/templates/abstract_request.erb
@@ -12,7 +12,12 @@ def detail_level=(value)
   @detail_levels = Array(value)
 end
 
+attr_accessor :rest_api_oauth_token
+
 def requester_credentials
+  # Skip RequesterCredentials when using OAuth2
+  return nil if respond_to?(:rest_api_oauth_token) && rest_api_oauth_token
+
   if auth_token || username || password
     XMLRequesterCredentials.new(:ebay_auth_token => auth_token, :username => username, :password => password)
   end

--- a/test/unit/ebay_test.rb
+++ b/test/unit/ebay_test.rb
@@ -229,4 +229,23 @@ class EbayTest < Test::Unit::TestCase
 
     assert_equal expected_request_context, ebay_api.request_context
   end
+
+  def test_oauth_request_excludes_requester_credentials
+    oauth_token = "v^1.1#i^1#I^3#p^3#f^...r^0#t^H4s"
+    request = Ebay::Requests::GeteBayOfficialTime.new(rest_api_oauth_token: oauth_token)
+    xml = request.save_to_xml.to_s
+
+    # Should NOT include RequesterCredentials when using OAuth2
+    assert_not_includes xml, '<RequesterCredentials>'
+    assert_not_includes xml, '<eBayAuthToken>'
+  end
+
+  def test_auth_request_includes_requester_credentials
+    request = Ebay::Requests::GeteBayOfficialTime.new(auth_token: 'test_auth_token')
+    xml = request.save_to_xml.to_s
+
+    # Should include RequesterCredentials when using Auth'n'Auth
+    assert_includes xml, '<RequesterCredentials>'
+    assert_includes xml, '<eBayAuthToken>test_auth_token</eBayAuthToken>'
+  end
 end

--- a/test/unit/ebay_test.rb
+++ b/test/unit/ebay_test.rb
@@ -248,4 +248,33 @@ class EbayTest < Test::Unit::TestCase
     assert_includes xml, '<RequesterCredentials>'
     assert_includes xml, '<eBayAuthToken>test_auth_token</eBayAuthToken>'
   end
+
+  def test_commit_passes_oauth_token_to_request
+    oauth_token = "v^1.1#i^1#I^3#p^3#f^...r^0#t^H4s"
+    ebay = Api.new(rest_api_oauth_token: oauth_token)
+
+    Ebay::HttpMock.respond_with(@success)
+    # Call commit with a block to capture the request
+    captured_request = nil
+    ebay.send(:commit, Ebay::Requests::GeteBayOfficialTime, {}) do |request|
+      captured_request = request
+    end
+
+    # Verify OAuth token was passed to request
+    assert_equal oauth_token, captured_request.rest_api_oauth_token
+  end
+
+  def test_commit_without_oauth_token
+    ebay = Api.new  # No OAuth token
+
+    Ebay::HttpMock.respond_with(@success)
+    # Call commit with a block to capture the request
+    captured_request = nil
+    ebay.send(:commit, Ebay::Requests::GeteBayOfficialTime, {}) do |request|
+      captured_request = request
+    end
+
+    # Verify OAuth token is nil when not provided
+    assert_nil captured_request.rest_api_oauth_token
+  end
 end


### PR DESCRIPTION
This change allows to use OAuth tokens to authorize requests to Trading API according to eBay guidance:

> Before the introduction of the eBay RESTful APIs, all requests to the traditional APIs require you to authorize your requests with a system that's known as Auth'n'Auth (which stands for authentication and authorization).

> As you begin to use the new eBay RESTful APIs, you'll find the APIs require you to use OAuth access tokens for authorization. This can be confusing because it appears that you need to use two separate authorization mechanisms if you want to use multiple eBay APIs.

> The good news is that we're retooling some traditional APIs to support OAuth as an authorization mechanism. With this upgrade, you can now use OAuth tokens to authorize the requests you make to the following traditional APIs:
> * Trading API
> * Post Order API
> * Business Policy Management API

[source](https://developer.ebay.com/develop/guides-v2/authorization/authorization#using-oauth-with-the-ebay-traditional-apis) and more details
