### PR TITLE
fix: Use BigDecimal for XML amount parsing in MoneyNode

### DIFF
--- a/ebay.gemspec
+++ b/ebay.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "logger-application", "~> 0.0.2"
   s.add_dependency "libxml-ruby", ">= 2.9", "< 4"
   s.add_dependency "money", "~> 6.0"
+  s.add_dependency "rexml"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake", ">= 10.0"

--- a/lib/support/xml_mapping/money_node.rb
+++ b/lib/support/xml_mapping/money_node.rb
@@ -1,3 +1,4 @@
+require 'bigdecimal'
 require 'money'
 require 'xml/mapping/base'
 
@@ -8,7 +9,7 @@ class MoneyNode < XML::Mapping::SingleAttributeNode
   end
 
   def extract_attr_value(xml)
-    amount, currency = default_when_xpath_err{ [(@amount_path.first(xml).text.to_f * 100),
+    amount, currency = default_when_xpath_err{ [(BigDecimal(@amount_path.first(xml).text) * 100).to_i,
                                      @currency_path.first(xml).text]
                                   }
     Money.new(amount, currency)

--- a/test/unit/xml_mapping_money_node_test.rb
+++ b/test/unit/xml_mapping_money_node_test.rb
@@ -38,6 +38,19 @@ class MoneyNodeTest < Test::Unit::TestCase
     assert_equal 'CAD', item_xml.elements[1].attributes['currencyID']
   end
   
+  # Regression: with infinite_precision enabled (common in financial apps),
+  # to_f * 100 produces 1998.9999999999998 for '19.99' which leaks through
+  # as BigDecimal("1998.999...") instead of being rounded. BigDecimal parsing
+  # avoids this entirely.
+  def test_load_from_xml_float_precision
+    Money.default_infinite_precision = true
+    xml = '<Widget><Amount currencyID="USD">19.99</Amount></Widget>'
+    item = Widget.load_from_xml(REXML::Document.new(xml).root)
+    assert_equal 1999, item.amount.cents
+  ensure
+    Money.default_infinite_precision = false
+  end
+
   # Detect bug in Money library v 2.0.0
   def test_to_xml_without_default
     item = Gizmo.new


### PR DESCRIPTION
## Summary

Replace `.to_f` with `BigDecimal()` when parsing XML money amounts to avoid Float precision loss. The old code did `text.to_f * 100` which produces `1998.9999999999998` instead of `1999` for `'19.99'`. This was hidden on bigdecimal < 3.1 because `Float#to_d` silently rounded the error (Bug [#13331](https://bugs.ruby-lang.org/issues/13331)), but bigdecimal 3.1+ preserves the exact Float representation. When `Money.infinite_precision` is enabled, the imprecise value leaks through and `cents` returns `1998` instead of `1999`.

|                    | bigdecimal 3.0.0       | bigdecimal 3.1.5              |
|--------------------|------------------------|-------------------------------|
| `float.to_d`       | `0.1999e4` (rounded)   | `0.1998999999999999e4` (exact) |
| `float.to_d.to_i`  | `1999` ✓               | `1998` ✗                       |


### References
- https://bugs.ruby-lang.org/issues/13331